### PR TITLE
Add autoequal to reduce equatable boilerplate

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,6 @@
 {
-    "editor.tabSize": 2
+    "editor.tabSize": 2,
+    "cSpell.words": [
+        "autoequal"
+    ]
 }

--- a/lib/src/modules/bloc_screen/bloc/counter_bloc.dart
+++ b/lib/src/modules/bloc_screen/bloc/counter_bloc.dart
@@ -1,6 +1,8 @@
+import 'package:autoequal/autoequal.dart';
 import 'package:bloc/bloc.dart';
 import 'package:equatable/equatable.dart';
 
+part 'counter_bloc.g.dart';
 part 'counter_event.dart';
 part 'counter_state.dart';
 

--- a/lib/src/modules/bloc_screen/bloc/counter_event.dart
+++ b/lib/src/modules/bloc_screen/bloc/counter_event.dart
@@ -2,11 +2,12 @@ part of 'counter_bloc.dart';
 
 abstract class CounterEvent extends Equatable {
   const CounterEvent();
-
-  @override
-  List<Object> get props => [];
 }
 
-class CounterIncreased extends CounterEvent {}
+@autoequalMixin
+class CounterIncreased extends CounterEvent
+    with _$CounterIncreasedAutoequalMixin {}
 
-class CounterDecreased extends CounterEvent {}
+@autoequalMixin
+class CounterDecreased extends CounterEvent
+    with _$CounterDecreasedAutoequalMixin {}

--- a/lib/src/modules/bloc_screen/bloc/counter_state.dart
+++ b/lib/src/modules/bloc_screen/bloc/counter_state.dart
@@ -1,13 +1,11 @@
 part of 'counter_bloc.dart';
 
-class CounterState extends Equatable {
+@autoequalMixin
+class CounterState extends Equatable with _$CounterStateAutoequalMixin {
   final int value;
   const CounterState({this.value = 0});
 
   CounterState copyWith({int? value}) => CounterState(
         value: value ?? this.value,
       );
-
-  @override
-  List<Object> get props => [value];
 }

--- a/lib/src/modules/cubit_screen/cubit/counter_cubit.dart
+++ b/lib/src/modules/cubit_screen/cubit/counter_cubit.dart
@@ -1,6 +1,8 @@
+import 'package:autoequal/autoequal.dart';
 import 'package:bloc/bloc.dart';
 import 'package:equatable/equatable.dart';
 
+part 'counter_cubit.g.dart';
 part 'counter_state.dart';
 
 class CounterCubit extends Cubit<CounterState> {

--- a/lib/src/modules/cubit_screen/cubit/counter_state.dart
+++ b/lib/src/modules/cubit_screen/cubit/counter_state.dart
@@ -1,13 +1,11 @@
 part of 'counter_cubit.dart';
 
-class CounterState extends Equatable {
+@autoequalMixin
+class CounterState extends Equatable with _$CounterStateAutoequalMixin {
   final int value;
   const CounterState({this.value = 0});
 
   CounterState copyWith({int? value}) => CounterState(
         value: value ?? this.value,
       );
-
-  @override
-  List<Object> get props => [value];
 }

--- a/lib/src/modules/main_screen/bloc/main_screen_bloc.dart
+++ b/lib/src/modules/main_screen/bloc/main_screen_bloc.dart
@@ -1,7 +1,9 @@
+import 'package:autoequal/autoequal.dart';
 import 'package:bloc/bloc.dart';
 import 'package:equatable/equatable.dart';
 import 'package:template/src/repositories/user_repository/user_repository.dart';
 
+part 'main_screen_bloc.g.dart';
 part 'main_screen_event.dart';
 part 'main_screen_state.dart';
 

--- a/lib/src/modules/main_screen/bloc/main_screen_event.dart
+++ b/lib/src/modules/main_screen/bloc/main_screen_event.dart
@@ -4,13 +4,19 @@ abstract class MainScreenEvent extends Equatable {
   const MainScreenEvent();
 
   @override
-  List<Object> get props => [];
+  List<Object?> get props => [];
 }
 
-class InitEvent extends MainScreenEvent {}
+@autoequalMixin
+class InitEvent extends MainScreenEvent with _$InitEventAutoequalMixin {}
 
-class AddUserEvent extends MainScreenEvent {}
+@autoequalMixin
+class AddUserEvent extends MainScreenEvent with _$AddUserEventAutoequalMixin {}
 
-class RemoveUserEvent extends MainScreenEvent {}
+@autoequalMixin
+class RemoveUserEvent extends MainScreenEvent
+    with _$RemoveUserEventAutoequalMixin {}
 
-class ReportSentryError extends MainScreenEvent {}
+@autoequalMixin
+class ReportSentryError extends MainScreenEvent
+    with _$ReportSentryErrorAutoequalMixin {}

--- a/lib/src/modules/main_screen/bloc/main_screen_state.dart
+++ b/lib/src/modules/main_screen/bloc/main_screen_state.dart
@@ -1,13 +1,11 @@
 part of 'main_screen_bloc.dart';
 
-class MainScreenState extends Equatable {
+@autoequalMixin
+class MainScreenState extends Equatable with _$MainScreenStateAutoequalMixin {
   final User? user;
   const MainScreenState({
     this.user,
   });
-
-  @override
-  List<Object?> get props => [user];
 }
 
 class InitState extends MainScreenState {}

--- a/lib/src/repositories/user_repository/src/models/user.dart
+++ b/lib/src/repositories/user_repository/src/models/user.dart
@@ -1,19 +1,22 @@
+import 'package:autoequal/autoequal.dart';
+import 'package:equatable/equatable.dart';
 import 'package:hive/hive.dart';
 
 part 'user.g.dart';
 
+@autoequalMixin
 @HiveType(typeId: 1)
-class User {
+class User extends Equatable with _$UserAutoequalMixin {
   @HiveField(0)
-  int pk;
+  final int pk;
   @HiveField(1)
-  String? email;
+  final String? email;
   @HiveField(2)
-  String? phone;
+  final String? phone;
   @HiveField(3)
-  String? firstName;
+  final String? firstName;
   @HiveField(4)
-  String? lastName;
+  final String? lastName;
 
   User({
     required this.pk,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -50,6 +50,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.2.3"
+  autoequal:
+    dependency: "direct main"
+    description:
+      name: autoequal
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.3.0"
+  autoequal_gen:
+    dependency: "direct dev"
+    description:
+      name: autoequal_gen
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.3.0"
   bloc:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ environment:
 
 dependencies:
   auto_route: ^3.2.4
+  autoequal: ^0.3.0
   equatable: ^2.0.3
   flutter:
     sdk: flutter
@@ -23,6 +24,7 @@ dependencies:
 
 dev_dependencies:
   auto_route_generator: ^3.2.3
+  autoequal_gen: ^0.3.0
   bloc_test: ^9.0.2
   build_runner: ^2.1.7
   flutter_lints: ^1.0.4


### PR DESCRIPTION
The boilerplate is not visible as much in the template but in ODRA or any future app this could generate a lot of code for us. Also, it would keep track of fields to compare by itself rather than making `Equatable` classes vulnerable to bugs due to programmer omission.
wyt?