### PR TITLE
Proposal: Add copy_with generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ class UserRepository with IHiveRepository<User> implements IUserRepository {
   }
 
   @override
-  Future<void> deleteUser(String userKey, User user) async {
+  Future<void> deleteUser(String userKey) async {
     await (await box).delete(userKey);
   }
 ```

--- a/ios/Flutter/App-defaults.xcconfig
+++ b/ios/Flutter/App-defaults.xcconfig
@@ -1,2 +1,0 @@
-APP_NAME=Dev app
-APP_SUFFIX=.dev

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:template/src/config/routes.dart';
 
 /// The Widget that configures your application.
@@ -22,15 +21,8 @@ class MyApp extends StatelessWidget {
         // Provide the generated AppLocalizations to the MaterialApp. This
         // allows descendant Widgets to display the correct translations
         // depending on the user's locale.
-        localizationsDelegates: const [
-          AppLocalizations.delegate,
-          GlobalMaterialLocalizations.delegate,
-          GlobalWidgetsLocalizations.delegate,
-          GlobalCupertinoLocalizations.delegate,
-        ],
-        supportedLocales: const [
-          Locale('en', ''), // English, no country code
-        ],
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
 
         // Use AppLocalizations to configure the correct application title
         // depending on the user's locale.

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -32,9 +32,6 @@ class MyApp extends StatelessWidget {
         onGenerateTitle: (BuildContext context) =>
             AppLocalizations.of(context)!.appTitle,
 
-        // Define a light and dark color theme. Then, read the user's
-        // preferred ThemeMode (light, dark, or system default) from the
-        // SettingsController to display the correct theme.
         theme: ThemeData(),
       );
 }

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -10,13 +10,14 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => MaterialApp.router(
-        routerDelegate: _router.delegate(),
+        routerDelegate: _router.delegate(
+          // Providing a navRestorationScopeId allows the Navigator built by the
+          // router to restore the navigation stack when a user leaves and
+          // returns to the app after it has been killed while running in the
+          // background.
+          navRestorationScopeId: 'app',
+        ),
         routeInformationParser: _router.defaultRouteParser(),
-        // Providing a restorationScopeId allows the Navigator built by the
-        // MaterialApp to restore the navigation stack when a user leaves and
-        // returns to the app after it has been killed while running in the
-        // background.
-        restorationScopeId: 'app',
 
         // Provide the generated AppLocalizations to the MaterialApp. This
         // allows descendant Widgets to display the correct translations

--- a/lib/src/modules/bloc_screen/bloc/counter_bloc.dart
+++ b/lib/src/modules/bloc_screen/bloc/counter_bloc.dart
@@ -1,5 +1,6 @@
 import 'package:autoequal/autoequal.dart';
 import 'package:bloc/bloc.dart';
+import 'package:copy_with_extension/copy_with_extension.dart';
 import 'package:equatable/equatable.dart';
 
 part 'counter_bloc.g.dart';
@@ -13,10 +14,10 @@ class CounterBloc extends Bloc<CounterEvent, CounterState> {
   }
 
   void _onIncreased(CounterIncreased event, Emitter<CounterState> emit) {
-    emit(state.copyWith(value: state.value + 1));
+    emit(state.copyWith.value(state.value + 1));
   }
 
   void _onDecreased(CounterDecreased event, Emitter<CounterState> emit) {
-    emit(state.copyWith(value: state.value - 1));
+    emit(state.copyWith.value(state.value - 1));
   }
 }

--- a/lib/src/modules/bloc_screen/bloc/counter_state.dart
+++ b/lib/src/modules/bloc_screen/bloc/counter_state.dart
@@ -1,11 +1,8 @@
 part of 'counter_bloc.dart';
 
+@CopyWith()
 @autoequalMixin
 class CounterState extends Equatable with _$CounterStateAutoequalMixin {
   final int value;
   const CounterState({this.value = 0});
-
-  CounterState copyWith({int? value}) => CounterState(
-        value: value ?? this.value,
-      );
 }

--- a/lib/src/modules/cubit_screen/cubit/counter_cubit.dart
+++ b/lib/src/modules/cubit_screen/cubit/counter_cubit.dart
@@ -1,5 +1,6 @@
 import 'package:autoequal/autoequal.dart';
 import 'package:bloc/bloc.dart';
+import 'package:copy_with_extension/copy_with_extension.dart';
 import 'package:equatable/equatable.dart';
 
 part 'counter_cubit.g.dart';
@@ -8,7 +9,7 @@ part 'counter_state.dart';
 class CounterCubit extends Cubit<CounterState> {
   CounterCubit() : super(const CounterState());
 
-  void increment() => emit(state.copyWith(value: state.value + 1));
+  void increment() => emit(state.copyWith.value(state.value + 1));
 
-  void decrement() => emit(state.copyWith(value: state.value - 1));
+  void decrement() => emit(state.copyWith.value(state.value - 1));
 }

--- a/lib/src/modules/cubit_screen/cubit/counter_state.dart
+++ b/lib/src/modules/cubit_screen/cubit/counter_state.dart
@@ -1,11 +1,8 @@
 part of 'counter_cubit.dart';
 
+@CopyWith()
 @autoequalMixin
 class CounterState extends Equatable with _$CounterStateAutoequalMixin {
   final int value;
   const CounterState({this.value = 0});
-
-  CounterState copyWith({int? value}) => CounterState(
-        value: value ?? this.value,
-      );
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -197,6 +197,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.1"
+  copy_with_extension:
+    dependency: "direct main"
+    description:
+      name: copy_with_extension
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.0.0"
+  copy_with_extension_gen:
+    dependency: "direct dev"
+    description:
+      name: copy_with_extension_gen
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.0.1"
   coverage:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ environment:
 dependencies:
   auto_route: ^3.2.4
   autoequal: ^0.3.0
+  copy_with_extension: ^4.0.0
   equatable: ^2.0.3
   flutter:
     sdk: flutter
@@ -27,6 +28,7 @@ dev_dependencies:
   autoequal_gen: ^0.3.0
   bloc_test: ^9.0.2
   build_runner: ^2.1.7
+  copy_with_extension_gen: ^4.0.1
   flutter_lints: ^1.0.4
   flutter_native_splash: ^2.0.5
   flutter_test:


### PR DESCRIPTION
Let's save us even more typing on state and data classes by generating the `copyWith` code. Wyt?

I considered freezed but it does require a particular way of declaring classes and I prefer sticking to the elasticity of extending classes with methods that we actually want. 