### PR TITLE
[refactor] Bump dependencies, lint 2.0.1 changes

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -43,5 +43,7 @@
 		</array>
 		<key>UIViewControllerBasedStatusBarAppearance</key>
 		<false/>
-	</dict>
+		<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
+</dict>
 </plist>

--- a/lib/src/modules/bloc_screen/bloc/counter_bloc.dart
+++ b/lib/src/modules/bloc_screen/bloc/counter_bloc.dart
@@ -1,7 +1,7 @@
 import 'package:autoequal/autoequal.dart';
-import 'package:bloc/bloc.dart';
 import 'package:copy_with_extension/copy_with_extension.dart';
 import 'package:equatable/equatable.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 
 part 'counter_bloc.g.dart';
 part 'counter_event.dart';

--- a/lib/src/modules/cubit_screen/cubit/counter_cubit.dart
+++ b/lib/src/modules/cubit_screen/cubit/counter_cubit.dart
@@ -1,7 +1,7 @@
 import 'package:autoequal/autoequal.dart';
-import 'package:bloc/bloc.dart';
 import 'package:copy_with_extension/copy_with_extension.dart';
 import 'package:equatable/equatable.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 
 part 'counter_cubit.g.dart';
 part 'counter_state.dart';

--- a/lib/src/modules/main_screen/bloc/main_screen_bloc.dart
+++ b/lib/src/modules/main_screen/bloc/main_screen_bloc.dart
@@ -1,6 +1,6 @@
 import 'package:autoequal/autoequal.dart';
-import 'package:bloc/bloc.dart';
 import 'package:equatable/equatable.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:template/src/repositories/user_repository/user_repository.dart';
 
 part 'main_screen_bloc.g.dart';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -21,7 +21,7 @@ packages:
       name: archive
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.6"
+    version: "3.1.11"
   args:
     dependency: transitive
     description:
@@ -42,14 +42,14 @@ packages:
       name: auto_route
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.2.4"
+    version: "4.0.1"
   auto_route_generator:
     dependency: "direct dev"
     description:
       name: auto_route_generator
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.2.3"
+    version: "4.0.0"
   autoequal:
     dependency: "direct main"
     description:
@@ -189,7 +189,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   convert:
     dependency: transitive
     description:
@@ -217,7 +217,7 @@ packages:
       name: coverage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "1.2.0"
   crypto:
     dependency: transitive
     description:
@@ -259,7 +259,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   ffi:
     dependency: transitive
     description:
@@ -304,7 +304,7 @@ packages:
       name: flutter_lints
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "2.0.1"
   flutter_localizations:
     dependency: "direct main"
     description: flutter
@@ -434,7 +434,7 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.3"
+    version: "0.6.4"
   json_annotation:
     dependency: transitive
     description:
@@ -455,7 +455,7 @@ packages:
       name: lints
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "2.0.0"
   logging:
     dependency: transitive
     description:
@@ -476,7 +476,7 @@ packages:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "0.1.4"
   meta:
     dependency: transitive
     description:
@@ -567,7 +567,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   path_provider:
     dependency: transitive
     description:
@@ -754,7 +754,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   stack_trace:
     dependency: transitive
     description:
@@ -803,21 +803,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.19.5"
+    version: "1.20.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.8"
+    version: "0.4.9"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.9"
+    version: "0.4.11"
   timing:
     dependency: transitive
     description:
@@ -859,14 +859,14 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.5.0"
+    version: "8.2.2"
   watcher:
     dependency: transitive
     description:
@@ -924,5 +924,5 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.16.0 <3.0.0"
+  dart: ">=2.17.0-206.0.dev <3.0.0"
   flutter: ">=2.8.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  auto_route: ^3.2.4
+  auto_route: ^4.0.1
   autoequal: ^0.3.0
   copy_with_extension: ^4.0.0
   equatable: ^2.0.3
@@ -24,12 +24,12 @@ dependencies:
   sentry_flutter: ^6.3.0
 
 dev_dependencies:
-  auto_route_generator: ^3.2.3
+  auto_route_generator: ^4.0.0
   autoequal_gen: ^0.3.0
   bloc_test: ^9.0.2
   build_runner: ^2.1.7
   copy_with_extension_gen: ^4.0.1
-  flutter_lints: ^1.0.4
+  flutter_lints: ^2.0.1
   flutter_native_splash: ^2.0.5
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
So, new flutter, new problems. Pretty sure you have already faced with some errors, luckily, changes are not so huge as with null safety migration. So for our template bumping version and some small lint fixes were needed.

FYI:
[auto_route issue](https://github.com/Milad-Akarie/auto_route_library/issues/1065) 
[other packages with similar issues](https://github.com/LianjiaTech/keframe/issues/13#issuecomment-1124376476)